### PR TITLE
Prevents participation of peers with no devices in LB / SC

### DIFF
--- a/Broker/src/lb/LoadBalance.cpp
+++ b/Broker/src/lb/LoadBalance.cpp
@@ -936,15 +936,13 @@ void LBAgent::HandleCollectedState(MessagePtr msg, PeerNodePtr peer)
     int peercount=0;
     double agg_gateway=0;
     ptree &pt = msg->GetSubMessages();
+
 	BOOST_FOREACH(ptree::value_type &v, pt.get_child("CollectedState.state"))
 	{
 	    Logger.Notice << "SC module returned values: "
-			  << v.second.get<double>("value") << std::endl;
-        if( v.second.get<int>("count") > 0 )
-        {
-            peercount++;
-            agg_gateway += v.second.get<double>("value");
-        }
+			  << v.second.data() << std::endl;
+        peercount++;
+        agg_gateway += boost::lexical_cast<double>(v.second.data());
 	}
 
 	//Consider any intransit "accept" messages in agg_gateway calculation

--- a/Broker/src/sc/StateCollection.cpp
+++ b/Broker/src/sc/StateCollection.cpp
@@ -245,10 +245,12 @@ void SCAgent::StateResponse()
             {
                 if ((*it).second.get<std::string>("sc.type")== m_valueType)
                 {
+                    if( (*it).second.get<std::size_t>("sc.count") > 0 )
+                    {
                     Logger.Status << "Marker: "<<(*it).first.first << " + " << (*it).first.second << "  Value:"
                                   << (*it).second.get<std::string>("sc.value") << std::endl;
                     m_.m_submessages.add("CollectedState.state.value", (*it).second.get<std::string>("sc.value"));
-                    m_.m_submessages.add("CollectedState.state.count", (*it).second.get<std::string>("sc.count"));
+                    }
                 }
                 else if ((*it).second.get<std::string>("sc.type")== "Message")
                 {


### PR DESCRIPTION
Two fixes required for plug and play devices that are also broken in master:

A node will consider itself in the normal state regardless of the computed normal value if it does not have a device capable of migrations.

A peer will report the number of device it has to its group leader during state collection. If a peer reports that it has no devices, then it will be excluded from the state report.
