### PR TITLE
Uninitialized memory in CBroker::RegisterModule

### DIFF
--- a/Broker/src/CBroker.cpp
+++ b/Broker/src/CBroker.cpp
@@ -218,7 +218,7 @@ void CBroker::RegisterModule(CBroker::ModuleIdent m, boost::posix_time::time_dur
     Logger.Trace << __PRETTY_FUNCTION__ << std::endl;
     m_schmutex.lock();
     boost::system::error_code err;
-    bool exists;
+    bool exists = false;
     for(unsigned int i=0; i < m_modules.size(); i++)
     {
         if(m_modules[i].first == m)


### PR DESCRIPTION
```
/home/michael/freedm/Broker/src/CBroker.cpp:222:27: warning: variable 'exists' is used uninitialized whenever
      'for' loop exits because its condition is false [-Wsometimes-uninitialized]
    for(unsigned int i=0; i < m_modules.size(); i++)
                          ^~~~~~~~~~~~~~~~~~~~
/home/michael/freedm/Broker/src/CBroker.cpp:230:9: note: uninitialized use occurs here
    if(!exists)
        ^~~~~~
/home/michael/freedm/Broker/src/CBroker.cpp:222:27: note: remove the condition if it is always true
    for(unsigned int i=0; i < m_modules.size(); i++)
                          ^~~~~~~~~~~~~~~~~~~~
/home/michael/freedm/Broker/src/CBroker.cpp:221:16: note: initialize the variable 'exists' to silence this warning
    bool exists;
               ^
                = false
```
