### PR TITLE
Fix return value when timings cannot be read

### DIFF
--- a/Broker/src/CTimings.cpp
+++ b/Broker/src/CTimings.cpp
@@ -204,7 +204,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     {
         Logger.Error << "Unable to timing config file: "
                 << timingsFile << std::endl;
-        std::exit(-1);
+        std::exit(1);
     }
     else
     {

--- a/Broker/timings/templates/cpp_base.tpl
+++ b/Broker/timings/templates/cpp_base.tpl
@@ -36,7 +36,7 @@ $parameter_block2
     {
         Logger.Error << "Unable to timing config file: "
                 << timingsFile << std::endl;
-        std::exit(-1);
+        std::exit(1);
     }
     else
     {


### PR DESCRIPTION
Fix a return value mistake.

When you return an exit status, all but the lowest byte is discarded.  So exit(-1) and exit(0) are exactly the same.
