### PR TITLE
Improve use of exceptions overall

### DIFF
--- a/Broker/include/CConnection.hpp
+++ b/Broker/include/CConnection.hpp
@@ -44,6 +44,14 @@ namespace freedm {
 
 class IProtocol;
 
+/// Used for errors communicating with peers.
+struct EConnectionError
+    : virtual std::runtime_error
+{
+    EConnectionError(const std::string& what)
+        : std::runtime_error(what) { }
+};
+
 /// Represents a single outgoing connection to a client.
 class CConnection
     : public CReliableConnection

--- a/Broker/include/FreedmExceptions.hpp
+++ b/Broker/include/FreedmExceptions.hpp
@@ -1,0 +1,45 @@
+////////////////////////////////////////////////////////////////////////////////
+/// @file           FreedmExceptions.hpp
+///
+/// @author         Michael Catanzaro <michael.catanzaro@mst.edu>
+///
+/// @project        FREEDM DGI
+///
+/// @description    A header for FREEDM exceptions applicable across the tree.
+///                 Exceptions applicable to specific files or modules belong
+///                 in those locations.
+///
+/// These source code files were created at Missouri University of Science and
+/// Technology, and are intended for use in teaching or research. They may be
+/// freely copied, modified, and redistributed as long as modified versions are
+/// clearly marked as such and this notice is not removed. Neither the authors
+/// nor Missouri S&T make any warranty, express or implied, nor assume any legal
+/// responsibility for the accuracy, completeness, or usefulness of these files
+/// or any information distributed with these files.
+///
+/// Suggested modifications or questions about these files can be directed to
+/// Dr. Bruce McMillin, Department of Computer Science, Missouri University of
+/// Science and Technology, Rolla, MO 65409 <ff@mst.edu>.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef FREEDM_EXCEPTIONS_HPP
+#define FREEDM_EXCEPTIONS_HPP
+
+#include <stdexcept>
+
+namespace freedm {
+namespace broker {
+
+/// Used when the DGI has been misconfigured
+struct EDgiConfigError
+    : virtual std::runtime_error
+{
+    EDgiConfigError(const std::string& what)
+        : std::runtime_error(what) { }
+};
+
+}
+}
+
+#endif
+

--- a/Broker/include/IHandler.hpp
+++ b/Broker/include/IHandler.hpp
@@ -46,6 +46,14 @@ namespace broker {
 
 class IPeerNode;
 
+/// Used when the DGI has been misconfigured
+struct EUnhandledMessage
+    : virtual std::runtime_error
+{
+    EUnhandledMessage(const std::string& what)
+        : std::runtime_error(what) { }
+};
+
 ///An interface for an object which can handle recieving incoming messages
 class IReadHandler
 {

--- a/Broker/src/CConnectionManager.cpp
+++ b/Broker/src/CConnectionManager.cpp
@@ -266,7 +266,7 @@ ConnectionPtr CConnectionManager::GetConnectionByUUID(std::string uuid_)
     {
         std::stringstream ss;
         ss<<"Error connecting to host "<<s_<<":"<<port<<": "<< e.what();
-        throw std::runtime_error(ss.str());
+        throw EConnectionError(ss.str());
     }
     // *it is safe only if we get here
     Logger.Info<<"Resolved: "<<static_cast<boost::asio::ip::udp::endpoint>(*it)<<std::endl;

--- a/Broker/src/CDispatcher.cpp
+++ b/Broker/src/CDispatcher.cpp
@@ -136,7 +136,6 @@ void CDispatcher::HandleRequest(CBroker &broker, MessagePtr msg)
     catch( boost::property_tree::ptree_bad_path &e )
     {
         Logger.Error
-            << __PRETTY_FUNCTION__ << " (" << __LINE__ << "): "
             << "Malformed message. Does not contain 'submessages'."
             << std::endl << "\t" << e.what() << std::endl;
     }

--- a/Broker/src/CLogger.cpp
+++ b/Broker/src/CLogger.cpp
@@ -135,7 +135,7 @@ unsigned int CGlobalLogger::GetOutputLevel(const std::string logger) const
     OutputMap::const_iterator it = m_loggers.find(logger);
     if (it == m_loggers.end())
     {
-        throw std::string(
+        throw std::runtime_error(
                 "Requested output level of unregistered logger " + logger);
     }
     return m_loggers.find(logger)->second;

--- a/Broker/src/CTimings.cpp
+++ b/Broker/src/CTimings.cpp
@@ -2,6 +2,7 @@
 
 #include "CTimings.hpp"
 #include "CLogger.hpp"
+#include "FreedmExceptions.hpp"
 
 #include <fstream>
 
@@ -202,9 +203,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     ifs.open(timingsFile.c_str());
     if (!ifs)
     {
-        Logger.Error << "Unable to timing config file: "
-                << timingsFile << std::endl;
-        std::exit(-1);
+        throw EDgiConfigError("Unable to open timings config " + timingsFile);
     }
     else
     {
@@ -222,7 +221,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "GM_PHASE_TIME is missing, please check your timings config");
     }
 
@@ -232,7 +231,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "GM_FID_TIMEOUT is missing, please check your timings config");
     }
 
@@ -242,7 +241,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "SC_PHASE_TIME is missing, please check your timings config");
     }
 
@@ -252,7 +251,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "RTDS_RUN_DELAY is missing, please check your timings config");
     }
 
@@ -262,7 +261,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "GM_AYC_RESPONSE_TIMEOUT is missing, please check your timings config");
     }
 
@@ -272,7 +271,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "GM_AYT_RESPONSE_TIMEOUT is missing, please check your timings config");
     }
 
@@ -282,7 +281,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "CS_EXCHANGE_TIME is missing, please check your timings config");
     }
 
@@ -292,7 +291,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "GM_GLOBAL_TIMEOUT is missing, please check your timings config");
     }
 
@@ -302,7 +301,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "LB_GLOBAL_TIMER is missing, please check your timings config");
     }
 
@@ -312,7 +311,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "GM_PREMERGE_MAX_TIMEOUT is missing, please check your timings config");
     }
 
@@ -322,7 +321,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "CSRC_RESEND_TIME is missing, please check your timings config");
     }
 
@@ -332,7 +331,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "GM_INVITE_RESPONSE_TIMEOUT is missing, please check your timings config");
     }
 
@@ -342,7 +341,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "GM_PREMERGE_GRANULARITY is missing, please check your timings config");
     }
 
@@ -352,7 +351,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "GM_PREMERGE_MIN_TIMEOUT is missing, please check your timings config");
     }
 
@@ -362,7 +361,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "LB_STATE_TIMER is missing, please check your timings config");
     }
 
@@ -372,7 +371,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "GM_CHECK_TIMEOUT is missing, please check your timings config");
     }
 
@@ -382,7 +381,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "LB_SC_QUERY_TIME is missing, please check your timings config");
     }
 
@@ -392,7 +391,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "CSUC_RESEND_TIME is missing, please check your timings config");
     }
 
@@ -402,7 +401,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "GM_TIMEOUT_TIMEOUT is missing, please check your timings config");
     }
 
@@ -412,7 +411,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "CSRC_DEFAULT_TIMEOUT is missing, please check your timings config");
     }
 
@@ -422,7 +421,7 @@ void CTimings::SetTimings(const std::string timingsFile)
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "LB_PHASE_TIME is missing, please check your timings config");
     }
 

--- a/Broker/src/IHandler.cpp
+++ b/Broker/src/IHandler.cpp
@@ -82,7 +82,7 @@ void IReadHandler::HandleRead(MessagePtr msg)
     }
     if(msg->GetHandler() == "")
     {
-        throw std::runtime_error("Message didn't specify a handler");
+        throw EUnhandledMessage("Message didn't specify a handler");
     }
     //Try to find the key in the map, unless its type is any:
     BOOST_FOREACH(SubhandleContainer::value_type f, m_handlers)

--- a/Broker/src/IProtocol.cpp
+++ b/Broker/src/IProtocol.cpp
@@ -61,7 +61,7 @@ void IProtocol::Write(CMessage msg)
     catch( std::exception &e )
     {
         Logger.Error<<"Couldn't write message to string stream."<<std::endl;
-        throw e;
+        throw;
     }
     raw = oss.str();
     /// Check to make sure it isn't goint to overfill our message packet:
@@ -69,7 +69,7 @@ void IProtocol::Write(CMessage msg)
     {
         Logger.Info << "Message too long for buffer" << std::endl;
         Logger.Info << raw << std::endl;
-        throw std::logic_error("Outgoing message is to long for buffer"); 
+        throw std::runtime_error("Outgoing message is to long for buffer");
     }
     /// If that looks good, lets write it into our buffer.    
     it = m_buffer.begin();

--- a/Broker/src/gm/GroupManagement.cpp
+++ b/Broker/src/gm/GroupManagement.cpp
@@ -992,7 +992,7 @@ void GMAgent::HandleAny(MessagePtr msg, PeerNodePtr peer)
         Logger.Error<<"Unhandled Group Management Message"<<std::endl;
         msg->Save(Logger.Error);
         Logger.Error<<std::endl;
-        throw std::runtime_error("Unhandled Group Management Message");
+        throw EUnhandledMessage("Unhandled Group Management Message");
     }
 }
 #pragma GCC diagnostic warning "-Wunused-parameter"

--- a/Broker/src/lb/LoadBalance.cpp
+++ b/Broker/src/lb/LoadBalance.cpp
@@ -625,7 +625,7 @@ void LBAgent::HandleAny(MessagePtr msg, PeerNodePtr peer)
         Logger.Error<<"Unhandled Load Balancing Message"<<std::endl;
         msg->Save(Logger.Error);
         Logger.Error<<std::endl;
-        throw std::runtime_error("Unhandled Load Balancing Message");
+        throw EUnhandledMessage("Unhandled Load Balancing Message");
     }
 }
 

--- a/Broker/src/sc/StateCollection.cpp
+++ b/Broker/src/sc/StateCollection.cpp
@@ -489,7 +489,7 @@ void SCAgent::HandleAny(MessagePtr msg, PeerNodePtr peer)
         Logger.Error<<"Unhandled State Collection Message"<<std::endl;
         msg->Save(Logger.Error);
         Logger.Error<<std::endl;
-        throw std::runtime_error("Unhandled State Collection Message");
+        throw EUnhandledMessage("Unhandled State Collection Message");
     }
 
     intransit = msg->GetHandler() + " from " + line_ + " to " + GetUUID();

--- a/Broker/timings/templates/cpp_base.tpl
+++ b/Broker/timings/templates/cpp_base.tpl
@@ -2,6 +2,7 @@
 
 #include "CTimings.hpp"
 #include "CLogger.hpp"
+#include "FreedmExceptions.hpp"
 
 #include <fstream>
 
@@ -34,9 +35,7 @@ $parameter_block2
     ifs.open(timingsFile.c_str());
     if (!ifs)
     {
-        Logger.Error << "Unable to timing config file: "
-                << timingsFile << std::endl;
-        std::exit(-1);
+        throw EDgiConfigError("Unable to open timings config " + timingsFile);
     }
     else
     {

--- a/Broker/timings/templates/cpp_parameter3.tpl
+++ b/Broker/timings/templates/cpp_parameter3.tpl
@@ -4,7 +4,7 @@
     }
     catch (boost::bad_any_cast& e)
     {
-        throw std::runtime_error(
+        throw EDgiConfigError(
                 "$parameter is missing, please check your timings config");
     }
 


### PR DESCRIPTION
Add a few exception classes and use them. Fixes a few cases of throwing
strings instead of exceptions. Also resolves a slicing issue. Big commit!

Devices are not touched since they are changed dramatically in PNP.

Fixes #15 (though this doesn't include reconfiguration mode, we no longer
use issues to track long-term plans, but rather specific bugs).
