### PR TITLE
load balance uses dgiEnable

### DIFF
--- a/Broker/include/device/types/CDeviceLogger.hpp
+++ b/Broker/include/device/types/CDeviceLogger.hpp
@@ -51,7 +51,13 @@ public:
 
     /// Virtual destructor for derived classes.
     virtual ~CDeviceLogger();
-    
+
+    /// Checks if the simulation is receiving DGI commands.
+    bool IsDgiEnabled() const;
+
+    /// Get the current simulation time (nan if not running).
+    SignalValue GetSimulationTime() const;    
+
     /// Sets the group status for this peer.
     void SetGroupStatus(const SignalValue status);
 private:

--- a/Broker/src/device/types/CDeviceLogger.cpp
+++ b/Broker/src/device/types/CDeviceLogger.cpp
@@ -67,6 +67,36 @@ CDeviceLogger::~CDeviceLogger()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Checks if the RTDS simulation is receiving DGI commands.
+///
+/// @pre None.
+/// @post Returns whether the simulation will respond to a command.
+/// @return True if the simulation is using DGI commands.
+///
+/// @limitations None.
+////////////////////////////////////////////////////////////////////////////////
+bool CDeviceLogger::IsDgiEnabled() const
+{
+    Logger.Trace << __PRETTY_FUNCTION__ << std::endl;
+    return Get("dgiEnable") == 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Returns the approximate time of a concurrent simulation.
+///
+/// @pre None.
+/// @post Returns the last simulation time received by the DGI.
+/// @return The simulation time if a simulation is running, nan otherwise.
+///
+/// @limitations None.
+////////////////////////////////////////////////////////////////////////////////
+SignalValue CDeviceLogger::GetSimulationTime() const
+{
+    Logger.Trace << __PRETTY_FUNCTION__ << std::endl;
+    return Get("simulationTime");
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Sets the current group membership status.
 ///
 /// @pre None.

--- a/Broker/src/lb/LoadBalance.cpp
+++ b/Broker/src/lb/LoadBalance.cpp
@@ -369,8 +369,15 @@ void LBAgent::LoadManage()
     // If you are in Supply state
     else if (LBAgent::SUPPLY == m_Status)
     {
-        //initiate draft request
-        SendDraftRequest();
+        using namespace device;
+        std::multiset<CDeviceLogger::Pointer> logger;
+        logger = CDeviceManager::Instance().GetDevicesOfType<CDeviceLogger>();
+
+        if( logger.empty() || (*logger.begin())->IsDgiEnabled() == true )
+        {
+            //initiate draft request
+            SendDraftRequest();
+        }
     }
 }//end LoadManage
 


### PR DESCRIPTION
Added two state signals to the logger device: dgiEnable and simulationTime

If there is a CDeviceLogger, load balance no longer sends draft requests unless dgiEnable == true.
If there is not a CDeviceLogger, load balance behaves as before this commit.
