### PR TITLE
Fix typo in endian swap

### DIFF
--- a/Broker/src/device/CRtdsAdapter.cpp
+++ b/Broker/src/device/CRtdsAdapter.cpp
@@ -280,7 +280,7 @@ void CRtdsAdapter::EndianSwapIfNeeded(std::vector<SignalValue> & v)
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     for( std::size_t i = 0; i < v.size(); i++ )
     {
-        ReverseBytes((char*)&v[0], sizeof(SignalValue));
+        ReverseBytes((char*)&v[i], sizeof(SignalValue));
     }
     
 #elif __BYTE_ORDER == __BIG_ENDIAN


### PR DESCRIPTION
The loop is extremely simple; the intent is to go through each element
in the list and reverse the bytes of each one separately. That's it. The
index is supposed to be i, not 0. I tried hard to make the code as
simple as possible so that we could be confident it worked; RtdsAdapter
had originally been reversing all the bytes in the entire buffer....
