### PR TITLE
Use isnan() to check for NaN values

### DIFF
--- a/PSCAD-Interface/src/CRtdsAdapter.cpp
+++ b/PSCAD-Interface/src/CRtdsAdapter.cpp
@@ -25,6 +25,7 @@
 #include "DeviceTable.hpp"
 
 #include <cassert>
+#include <cmath>
 #include <cstddef>
 
 #include <sys/param.h>
@@ -91,7 +92,7 @@ void CRtdsAdapter::HandleConnection()
             writeLock = CTableManager::AsWriter(COMMAND_TABLE);
             for( std::size_t i = 0; i < recvSize; i++ )
             {
-                if( recvBuffer[i] == recvBuffer[i] )
+                if( !isnan(recvBuffer[i]) )
                     writeLock->SetValue(m_CommandDetails[i],recvBuffer[i]);
             }
             writeLock.reset();


### PR DESCRIPTION
isnan() is specified by POSIX.1, so even though it's not part of C++98, this will still work pretty much everywhere except Windows.

It's also a bit less confusing to read than what I pushed yesterday.
