### PR TITLE
Put a mutex around CLog::write

### DIFF
--- a/Broker/src/CLogger.cpp
+++ b/Broker/src/CLogger.cpp
@@ -25,6 +25,7 @@
 #include "CGlobalConfiguration.hpp"
 
 #include <boost/program_options/options_description.hpp>
+#include <boost/thread/locks.hpp>
 #include <boost/thread/mutex.hpp>
 
 using namespace boost::posix_time;
@@ -62,11 +63,10 @@ std::streamsize CLog::write(const char* const s, std::streamsize n)
 {
     if (GetOutputLevel() >= m_level)
     {
-        mutex.lock();
+        boost::lock_guard<boost::mutex> lock(mutex);
         *m_ostream << microsec_clock::local_time() + CGlobalConfiguration::instance().GetClockSkew() << " : "
                 << m_name << "(" << m_level << "):\n\t";
         boost::iostreams::write(*m_ostream, s, n);
-        mutex.unlock();
     }
     return n;
 }


### PR DESCRIPTION
Issue #224 has me slightly stumped. But it does seem like our logging facility is not safe to use from multiple threads. This is the first possible fix that came to mind... I've started the DGI probably about 200ishish times now without getting any corruption, and it used to happen every maybe 30-60ish runs, so it might work... do please look this over.

Pull request attempt #2, with about 10,000 fewer modifications
