### PR TITLE
Changed power migration output from Warn to Notice.

### DIFF
--- a/Broker/src/lb/LoadBalance.cpp
+++ b/Broker/src/lb/LoadBalance.cpp
@@ -903,7 +903,7 @@ void LBAgent::HandleAccept(MessagePtr msg, PeerNodePtr peer)
     if( LBAgent::SUPPLY == m_Status)
     {
         // Make necessary power setting accordingly to allow power migration
-        Logger.Warn<<"Migrating power on request from: "<< peer->GetUUID() << std::endl;
+        Logger.Notice<<"Migrating power on request from: "<< peer->GetUUID() << std::endl;
 	// !!!NOTE: You may use Step_PStar() or PStar(DemandValue) currently
         if (m_sstExists)
            Step_PStar();


### PR DESCRIPTION
Changes logger level of "Migrating power on request from: ..." message from Warn to Notice.  Addresses issue #237. 
