### PR TITLE
Testing Script Fixes

### DIFF
--- a/DeviceController/testing/run_test.sh
+++ b/DeviceController/testing/run_test.sh
@@ -8,28 +8,29 @@ if [ -z $1 ]; then
     exit
 fi
 
-for i in $PREFIX/$1.txt $PREFIX/$1[A-Z].txt; do
+TEST=${1#scripts/}
+
+for i in $PREFIX/$TEST.txt $PREFIX/$TEST[A-Z].txt; do
     if [ -f $i ]; then
         CTR=${i%.txt}
-        CTR=${CTR#*[[:digit:]]}
+        CTR=${CTR##*[[:digit:]]}
         if [ -z $CTR ]; then
             CTR="TestController"
         fi
 
         PORT=53000
-        if [[ $1 == MultipleDGI* ]] && [ $CTR == "B" ]; then
+        if [[ $TEST == MultipleDGI* ]] && [ $CTR == "B" ]; then
             PORT=56000
         fi
 
         DUPLICATES=1
-        if [ $1 == "UnexpectedError5" ]; then
+        if [ $TEST == "UnexpectedError5" ]; then
             DUPLICATES=2
         fi
 
         for (( j=1; j<=DUPLICATES; j++ )); do
             echo "Starting controller $CTR on port $PORT using script $i..."
             ../fake_controller.py -c config/controller.cfg -s $i -n $CTR -p $PORT &
-            PORT=$(($PORT + 1))
         done
     fi
 done


### PR DESCRIPTION
-handles the case when a script has has two digits correctly
-no longer uses different port numbers for UnexpectedError5
-works both with and without the scripts/ prefix
