### PR TITLE
Remove dependency on Boost.Serialization

### DIFF
--- a/Broker/CMakeLists.txt
+++ b/Broker/CMakeLists.txt
@@ -32,8 +32,7 @@ message("This project uses custom CMake settings:"
     "\n\tChange a setting with -DSETTING=ON/OFF")
 
 # find the required boost libraries
-find_package(Boost REQUIRED COMPONENTS system thread program_options 
-             serialization date_time)
+find_package(Boost REQUIRED COMPONENTS system thread program_options date_time)
 
 # add the boost libraries to the project
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
@@ -78,7 +77,6 @@ target_link_libraries(
     device
     ${Boost_THREAD_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
-    ${Boost_SERIALIZATION_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Boost_DATE_TIME_LIBRARY}
 )

--- a/Broker/src/gm/GroupManagement.cpp
+++ b/Broker/src/gm/GroupManagement.cpp
@@ -58,9 +58,6 @@
 #include <boost/functional/hash.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/range/adaptor/map.hpp>
-#include <boost/serialization/string.hpp>
-#include <boost/serialization/vector.hpp>
-#include <boost/serialization/shared_ptr.hpp>
 
 using boost::property_tree::ptree;
 

--- a/Broker/src/sc/StateCollection.cpp
+++ b/Broker/src/sc/StateCollection.cpp
@@ -66,9 +66,6 @@
 #include <boost/function.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/range/adaptor/map.hpp>
-#include <boost/serialization/string.hpp>
-#include <boost/serialization/vector.hpp>
-#include <boost/serialization/shared_ptr.hpp>
 
 using boost::property_tree::ptree;
 


### PR DESCRIPTION
We don't appear to be using its functionality at all.

Fixes #266 
