### PR TITLE
Remove extra forward declaration

### DIFF
--- a/Broker/include/CDispatcher.hpp
+++ b/Broker/include/CDispatcher.hpp
@@ -49,8 +49,6 @@ using boost::property_tree::ptree;
 namespace freedm {
     namespace broker {
 
-class CMessage;
-
 /// Handles applying read and write handlers to incoming messages
 class CDispatcher
   : private boost::noncopyable


### PR DESCRIPTION
The corresponding header file is already included.  (Unfortunately it
does need to be included for the MessagePtr typedef....)
