### PR TITLE
Make IProtocol's constructor protected

### DIFF
--- a/Broker/include/IProtocol.hpp
+++ b/Broker/include/IProtocol.hpp
@@ -71,7 +71,7 @@ class IProtocol
         CConnection* GetConnection() { return m_conn; };
     protected:
         /// Initializes the protocol with the underlying connection
-        IProtocol(CConnection * conn) : m_conn(conn), m_stopped(false) { };
+        explicit IProtocol(CConnection * conn) : m_conn(conn), m_stopped(false) { };
         /// Callback for when a write completes.
         virtual void WriteCallback(const boost::system::error_code& e) { }
         /// Handles writing the message to the underlying connection


### PR DESCRIPTION
It's not hurting anything to be public, since it's noninstantiable.
But it also doesn't make any sense.
