### PR TITLE
Never process a message while sending one

### DIFF
--- a/Broker/src/CBroker.cpp
+++ b/Broker/src/CBroker.cpp
@@ -375,9 +375,7 @@ int CBroker::Schedule(ModuleIdent m, BoundScheduleable x, bool start_worker)
     m_ready[m].push_back(x);
     if(!m_busy && start_worker)
     {
-        schlock.unlock();
-        Worker();
-        schlock.lock();
+        m_ioService.post(boost::bind(&CBroker::Worker, this));
     }
     Logger.Debug<<"Module "<<m<<" now has queue size: "<<m_ready[m].size()<<std::endl;
     Logger.Debug<<"Scheduled task (NODELAY) for "<<m<<std::endl;
@@ -534,8 +532,7 @@ void CBroker::ScheduledTask(CBroker::Scheduleable x, CBroker::TimerHandle handle
     Logger.Debug<<"Module "<<module<<" now has queue size: "<<m_ready[module].size()<<std::endl;
     if(!m_busy)
     {
-        schlock.unlock();
-        Worker();
+        m_ioService.post(boost::bind(&CBroker::Worker, this));
     }
 }
 


### PR DESCRIPTION
If we send a message to ourselves, we will block exactly once per round
to process one message from our queue before the send call returns. This
is unexpected and could break potential future uses of message passing.

Also, according to Tom, it doesn't make any flipping sense.

P.S. untested ;)
