### PR TITLE
Fix const-correctness issues in CClockSynchronizer

### DIFF
--- a/Broker/src/CClockSynchronizer.cpp
+++ b/Broker/src/CClockSynchronizer.cpp
@@ -399,7 +399,7 @@ CMessage CClockSynchronizer::ExchangeResponse(unsigned int k)
 /// @post None
 /// @return The adjusted time.
 ///////////////////////////////////////////////////////////////////////////////
-boost::posix_time::ptime CClockSynchronizer::GetSynchronizedTime()
+boost::posix_time::ptime CClockSynchronizer::GetSynchronizedTime() const
 { 
     Logger.Trace << __PRETTY_FUNCTION__ << std::endl;
     boost::posix_time::ptime now = boost::posix_time::microsec_clock::universal_time();
@@ -414,16 +414,16 @@ boost::posix_time::ptime CClockSynchronizer::GetSynchronizedTime()
 /// @post None
 /// @return The weight
 ///////////////////////////////////////////////////////////////////////////////
-double CClockSynchronizer::GetWeight(MapIndex i)
+double CClockSynchronizer::GetWeight(MapIndex i) const
 {
     Logger.Trace << __PRETTY_FUNCTION__ << std::endl;
-    WeightMap::iterator it = m_weights.find(i);
+    WeightMap::const_iterator it = m_weights.find(i);
     boost::posix_time::ptime set;
     if(i == MapIndex(m_uuid,m_uuid))
         return 1.0;
     if(it == m_weights.end())
         throw std::runtime_error("Can't find that index in the weights table");
-    return it->second.first * pow(SYNCHRONIZER_LAMBDA,m_kcounter-m_lastresponse[i]);
+    return it->second.first * pow(SYNCHRONIZER_LAMBDA,m_kcounter-m_lastresponse.find(i)->second);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/Broker/src/CClockSynchronizer.hpp
+++ b/Broker/src/CClockSynchronizer.hpp
@@ -58,7 +58,7 @@ class CClockSynchronizer
     /// Generate the exchange response message
     CMessage ExchangeResponse(unsigned int k);
     /// Returns the synchronized time
-    boost::posix_time::ptime GetSynchronizedTime();
+    boost::posix_time::ptime GetSynchronizedTime() const;
     /// Starts the stuff.
     void Run();
     /// Stops the stuff
@@ -118,7 +118,7 @@ class CClockSynchronizer
     std::string m_uuid;
    
     /// Gets the weight with a decay 
-    double GetWeight(MapIndex i);
+    double GetWeight(MapIndex i) const;
     
     /// Sets the weight
     void SetWeight(MapIndex i, double w);


### PR DESCRIPTION
A couple functions in CClockSynchronizer ought to be const.
