### PR TITLE
trivial: style changes in top-level CMakeLists.txt

### DIFF
--- a/Broker/CMakeLists.txt
+++ b/Broker/CMakeLists.txt
@@ -17,12 +17,10 @@ option(DOXYGEN "run Doxygen after project compile" ON)
 option(TRACK_HANDLERS "enable Boost.Asio handler tracking" OFF)
 option(WARNINGS "warnings displayed during project compile" ON)
 
-# find the required boost libraries
+# Boost
 find_package(Boost 1.47 REQUIRED
              COMPONENTS date_time program_options system thread
             )
-
-# add the boost libraries to the project
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 
@@ -34,7 +32,8 @@ else()
 endif()
 
 # Use -DCMAKE_BUILD_TYPE to control optimization and debugging
-set(CMAKE_CXX_FLAGS "-pedantic -std=c++98 -pthread ${WARNING_FLAGS} ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS
+    "-pedantic -pthread -std=c++98 ${WARNING_FLAGS} ${CMAKE_CXX_FLAGS}")
 
 if(TRACK_HANDLERS)
     add_definitions(-DBOOST_ASIO_ENABLE_HANDLER_TRACKING)
@@ -61,10 +60,10 @@ add_dependencies(PosixBroker GeneratedPhysicalDeviceTypes)
 target_link_libraries(PosixBroker
                       broker
                       device
-                      ${Boost_THREAD_LIBRARY}
-                      ${Boost_SYSTEM_LIBRARY}
-                      ${Boost_PROGRAM_OPTIONS_LIBRARY}
                       ${Boost_DATE_TIME_LIBRARY}
+                      ${Boost_PROGRAM_OPTIONS_LIBRARY}
+                      ${Boost_SYSTEM_LIBRARY}
+                      ${Boost_THREAD_LIBRARY}
                      )
 
 if(DOXYGEN)


### PR DESCRIPTION
Changing comments and whitespace to reduce the diff with the protobuf branch.

If you want justifications for such minor changes, they are:
- Keep all the Boost changes clumped together, under one heading. Makes things easier to read when there's another dependency.
- The middle change keeps the compiler options under 80 chars (not that I am a fan of that limit).
- No justification for the alphabetization.
