### PR TITLE
CReliableConnection: remove Start() and Stop()

### DIFF
--- a/Broker/src/CReliableConnection.hpp
+++ b/Broker/src/CReliableConnection.hpp
@@ -56,12 +56,6 @@ public:
     /// Get the socket associated with the CConnection.
     boost::asio::ip::udp::socket& GetSocket();
 
-    /// Start the first asynchronous operation for the CConnection.
-    virtual void Start() = 0;
-
-    /// Stop all asynchronous operations associated with the CConnection.
-    virtual void Stop() = 0;
-
     /// Get associated UUID
     std::string GetUUID();
 


### PR DESCRIPTION
These are not needed in all of its children. They're never called polymorphically. And they're causing problems for me.
