### PR TITLE
Print an error when a connection fails

### DIFF
--- a/Broker/src/CConnectionManager.cpp
+++ b/Broker/src/CConnectionManager.cpp
@@ -264,11 +264,9 @@ ConnectionPtr CConnectionManager::GetConnectionByUUID(std::string uuid_)
     }
     catch (boost::system::system_error& e)
     {
-        std::stringstream ss;
-        ss<<"Error connecting to host "<<s_<<":"<<port<<": "<< e.what();
+        Logger.Warn<<"Error connecting to host "<<s_<<":"<<port<<": "<< e.what()<<std::endl;
         PutConnection(uuid_,c_);
         return c_;
-        //throw EConnectionError(ss.str());
     }
     // *it is safe only if we get here
     Logger.Info<<"Resolved: "<<static_cast<boost::asio::ip::udp::endpoint>(*it)<<std::endl;


### PR DESCRIPTION
The clear intent of this halfway-modified code was to print a warning.
