### PR TITLE
CBroker: assert that the round is nonzero

### DIFF
--- a/Broker/src/CBroker.cpp
+++ b/Broker/src/CBroker.cpp
@@ -41,6 +41,7 @@
 #include <boost/bind.hpp>
 #include <boost/foreach.hpp>
 
+#include <cassert>
 #include <map>
 
 /// General FREEDM Namespace
@@ -415,6 +416,7 @@ void CBroker::ChangePhase(const boost::system::error_code & /*err*/)
     {
         round += m_modules[i].second.total_milliseconds();
     }
+    assert(round > 0);
     unsigned int millisecs = time.total_milliseconds();
     unsigned int intoround = (millisecs % round);
     unsigned int cphase = 0;


### PR DESCRIPTION
The Clang static analyzer found a potential division by zero in
CBroker::ChangePhase(). The bug occurs when (a) there is at least one
module registered, and (b) every registered module has a phase duration
of zero. Obviously this is not a practical concern, but it would be good
to add an assertion to surpress the false positive. (It's also
independently not a bad idea.)
