### PR TITLE
Remove spurious warning surpression pragma

### DIFF
--- a/Broker/src/lb/LoadBalance.cpp
+++ b/Broker/src/lb/LoadBalance.cpp
@@ -1056,7 +1056,6 @@ void LBAgent::HandleComputedNormal(MessagePtr msg, PeerNodePtr /*peer*/)
                    << pt.get<std::string>("lb.source") << std::endl;
     LoadTable();
 }
-#pragma GCC diagnostic warning "-Wunused-parameter"
 
 ////////////////////////////////////////////////////////////
 /// Step_PStar


### PR DESCRIPTION
This is a leftover from when I didn't know how to handle unused
parameters properly. I tried to get rid of all of these, but evidently
missed a spot.
