### PR TITLE
sc: never store an incomplete state

### DIFF
--- a/Broker/src/sc/StateCollection.cpp
+++ b/Broker/src/sc/StateCollection.cpp
@@ -585,6 +585,7 @@ void SCAgent::HandleAny(MessagePtr msg, PeerNodePtr peer)
         sub_ptree.add("type", "Message");
         sub_ptree.add("signal", "inchannel");
         sub_ptree.add("value", intransit);
+        sub_ptree.add("count", 1);
         m_.m_submessages.add_child("sc.collects.collect", sub_ptree);
 
         m_curstate = m_.GetSubMessages();


### PR DESCRIPTION
We crash when we attempt to retrieve the missing field. Probably
fixes #269
