### PR TITLE
devices.xml is missing the root tag

### DIFF
--- a/Broker/config/samples/device.xml
+++ b/Broker/config/samples/device.xml
@@ -1,30 +1,32 @@
 <?xml version="1.0" encoding="us-ascii" ?>
-<deviceType>
-    <id>Sst</id>
-    <state>gateway</state>
-    <command>gateway</command>
-</deviceType>
-<deviceType>
-    <id>Desd</id>
-    <state>storage</state>
-    <command>storage</command>
-</deviceType>
-<deviceType>
-    <id>Drer</id>
-    <state>generation</state>
-    <command>generation</command>
-</deviceType>
-<deviceType>
-    <id>Load</id>
-    <state>drain</state>
-    <command>drain</command>
-</deviceType>
-<deviceType>
-    <id>Fid</id>
-    <state>state</state>
-</deviceType>
-<deviceType>
-    <id>Logger</id>
-    <state>dgiEnable</state>
-    <command>groupStatus</command>
-</deviceType>
+<root>
+    <deviceType>
+        <id>Sst</id>
+        <state>gateway</state>
+        <command>gateway</command>
+    </deviceType>
+    <deviceType>
+        <id>Desd</id>
+        <state>storage</state>
+        <command>storage</command>
+    </deviceType>
+    <deviceType>
+        <id>Drer</id>
+        <state>generation</state>
+        <command>generation</command>
+    </deviceType>
+    <deviceType>
+        <id>Load</id>
+        <state>drain</state>
+        <command>drain</command>
+    </deviceType>
+    <deviceType>
+        <id>Fid</id>
+        <state>state</state>
+    </deviceType>
+    <deviceType>
+        <id>Logger</id>
+        <state>dgiEnable</state>
+        <command>groupStatus</command>
+    </deviceType>
+</root>

--- a/Broker/src/device/CDeviceBuilder.cpp
+++ b/Broker/src/device/CDeviceBuilder.cpp
@@ -64,18 +64,20 @@ CDeviceBuilder::CDeviceBuilder(std::string filename)
 
     typedef std::map<std::string, DeviceInfo> map_type;
     using namespace boost::property_tree;
-    ptree device_xml;
+    ptree root;
     BuildVars vars;
 
     try
     {
         Logger.Debug << "read_xml with the path: " << filename << std::endl;
-        read_xml(filename, device_xml);
+        read_xml(filename, root);
     }
     catch(std::exception & e)
     {
         throw std::runtime_error(e.what());
     }
+
+    ptree device_xml = root.get_child("root");
 
     if( device_xml.size() == 0 )
     {

--- a/Broker/testing/config/device.xml
+++ b/Broker/testing/config/device.xml
@@ -1,30 +1,32 @@
 <?xml version="1.0" encoding="us-ascii" ?>
-<deviceType>
-    <id>Sst</id>
-    <state>gateway</state>
-    <command>gateway</command>
-</deviceType>
-<deviceType>
-    <id>Desd</id>
-    <state>storage</state>
-    <command>storage</command>
-</deviceType>
-<deviceType>
-    <id>Drer</id>
-    <state>generation</state>
-    <command>generation</command>
-</deviceType>
-<deviceType>
-    <id>Load</id>
-    <state>drain</state>
-    <command>drain</command>
-</deviceType>
-<deviceType>
-    <id>Fid</id>
-    <state>state</state>
-</deviceType>
-<deviceType>
-    <id>Logger</id>
-    <state>dgiEnable</state>
-    <command>groupStatus</command>
-</deviceType>
+<root>
+    <deviceType>
+        <id>Sst</id>
+        <state>gateway</state>
+        <command>gateway</command>
+    </deviceType>
+    <deviceType>
+        <id>Desd</id>
+        <state>storage</state>
+        <command>storage</command>
+    </deviceType>
+    <deviceType>
+        <id>Drer</id>
+        <state>generation</state>
+        <command>generation</command>
+    </deviceType>
+    <deviceType>
+        <id>Load</id>
+        <state>drain</state>
+        <command>drain</command>
+    </deviceType>
+    <deviceType>
+        <id>Fid</id>
+        <state>state</state>
+    </deviceType>
+    <deviceType>
+        <id>Logger</id>
+        <state>dgiEnable</state>
+        <command>groupStatus</command>
+    </deviceType>
+</root>


### PR DESCRIPTION
The sample devices configuration file is wrong, and the parser only
correctly parses the incorrect file.

Fixes #326

This isn't ready to be merged since it's not tested. This is a blocker for 1.6, since it affects the format of the new configuration file.
