### PR TITLE
add check for registration before timer is allocated for module

### DIFF
--- a/Broker/src/CBroker.cpp
+++ b/Broker/src/CBroker.cpp
@@ -321,7 +321,7 @@ CBroker::TimerHandle CBroker::AllocateTimer(CBroker::ModuleIdent module)
 	}
 	else
 	{
-		throw std::runtime_error("attempted to allocate time to unregistered module");
+		throw std::runtime_error("attempted to allocate time to unregistered module" + module);
 	}
 
 }

--- a/Broker/src/CBroker.cpp
+++ b/Broker/src/CBroker.cpp
@@ -321,7 +321,7 @@ CBroker::TimerHandle CBroker::AllocateTimer(CBroker::ModuleIdent module)
 	}
 	else
 	{
-		throw std::runtime_error("attempted to allocate time to unregistered module" + module);
+		throw std::runtime_error("attempted to allocate time to unregistered module " + module);
 	}
 
 }

--- a/Broker/src/gm/GroupManagement.cpp
+++ b/Broker/src/gm/GroupManagement.cpp
@@ -91,8 +91,6 @@ GMAgent::GMAgent()
     m_groupsjoined = 0;
     m_membership = 0;
     m_membershipchecks = 0;
-    m_timer = CBroker::Instance().AllocateTimer("gm");
-    m_fidtimer = CBroker::Instance().AllocateTimer("gm");
     m_GrpCounter = rand();
 }
 
@@ -1304,6 +1302,9 @@ CPeerNode GMAgent::GetPeer(const std::string& uuid)
 int GMAgent::Run()
 {
     Logger.Trace << __PRETTY_FUNCTION__ << std::endl;
+
+    m_timer = CBroker::Instance().AllocateTimer("gm");
+    m_fidtimer = CBroker::Instance().AllocateTimer("gm");
 
     std::map<std::string, SRemoteHost>::iterator mapIt_;
 

--- a/Broker/src/lb/LoadBalance.cpp
+++ b/Broker/src/lb/LoadBalance.cpp
@@ -95,9 +95,6 @@ LBAgent::LBAgent()
 {
     Logger.Trace << __PRETTY_FUNCTION__ << std::endl;
 
-    m_RoundTimer = CBroker::Instance().AllocateTimer("lb");
-    m_WaitTimer = CBroker::Instance().AllocateTimer("lb");
-
     m_State = LBAgent::NORMAL;
     m_Leader = GetUUID();
 
@@ -115,6 +112,11 @@ LBAgent::LBAgent()
 int LBAgent::Run()
 {
     Logger.Trace << __PRETTY_FUNCTION__ << std::endl;
+
+    m_RoundTimer = CBroker::Instance().AllocateTimer("lb");
+    m_WaitTimer = CBroker::Instance().AllocateTimer("lb");
+
+
     CBroker::Instance().Schedule(m_RoundTimer, boost::posix_time::not_a_date_time,
         boost::bind(&LBAgent::FirstRound, this, boost::asio::placeholders::error));
     Logger.Info << "LoadManage scheduled for the next phase." << std::endl;


### PR DESCRIPTION
I believe I have resolved this by updating AllocateTimer using the function IsModuleRegistered. Also, I don't know if there is a special procedure or documentation required for throwing this exception. This is issue #385 
